### PR TITLE
fix: 인증객체에 principal 이 유저의 id 값을 담도록 수정

### DIFF
--- a/src/main/java/com/poku/graypants/domain/user/web/UserController.java
+++ b/src/main/java/com/poku/graypants/domain/user/web/UserController.java
@@ -1,20 +1,15 @@
 package com.poku.graypants.domain.user.web;
 
-import static com.poku.graypants.global.util.ApiResponseUtil.error;
 import static com.poku.graypants.global.util.ApiResponseUtil.success;
 
 import com.poku.graypants.domain.user.application.UserService;
-import com.poku.graypants.global.config.oauth.PrincipalDetails;
 import com.poku.graypants.global.util.ApiResponseUtil.ApiResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -25,8 +20,8 @@ public class UserController {
     private final UserService userService;
 
     @GetMapping("/me")
-    public ResponseEntity<ApiResult<User>> me(Authentication authentication){
-        return new ResponseEntity<>(success((User)authentication.getPrincipal()), HttpStatus.OK);
+    public ResponseEntity<ApiResult<Long>> me(Authentication authentication) {
+        return new ResponseEntity<>(success((Long) authentication.getPrincipal()), HttpStatus.OK);
     }
 
 

--- a/src/main/java/com/poku/graypants/global/config/email/EmailSenderConfig.java
+++ b/src/main/java/com/poku/graypants/global/config/email/EmailSenderConfig.java
@@ -1,7 +1,6 @@
 package com.poku.graypants.global.config.email;
 
 import java.util.Properties;
-import lombok.AllArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -9,7 +8,7 @@ import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
 
 @Configuration
-public class EmailSenderConfigure {
+public class EmailSenderConfig {
 
 
     @Value("${spring.mail.host}")

--- a/src/main/java/com/poku/graypants/global/jwt/JwtProvider.java
+++ b/src/main/java/com/poku/graypants/global/jwt/JwtProvider.java
@@ -47,7 +47,7 @@ public class JwtProvider {
                 .setIssuer(jwtProperties.getIssuer())
                 .setIssuedAt(new Date())
                 .setExpiration(expirationDate)
-                .setSubject(user.getEmail())
+//                .setSubject(user.getEmail())
                 .claim("id", user.getUserId())
                 .signWith(getSigningKey())
                 .compact();
@@ -81,7 +81,7 @@ public class JwtProvider {
         Claims claims = getClaims(token);
         Set<SimpleGrantedAuthority> authorities = Collections.singleton(new SimpleGrantedAuthority("ROLE_USER"));
         return new UsernamePasswordAuthenticationToken(
-                new org.springframework.security.core.userdetails.User(claims.getSubject(), "", authorities),
+                claims.get("id", Long.class),
                 token,
                 authorities
         );


### PR DESCRIPTION
relatedTo: #12

## 기능 설명
인증된 유저ID 인증객체에 담아 컨트롤러에서 유저를 판별하는 기능 

## 작업 내용
jwt 내용 및 jwt 필터 과정 변경

## 수정 사항
jwt에 email이 아닌 user_id를 담도록 수정
authentication 객체에 principal 필드를 user_id를 저장하도록 수정

## 추가 작업 예정
